### PR TITLE
Fix anchor scroll offset and make empty search list everything

### DIFF
--- a/frontend/src/assets/styles/base.css
+++ b/frontend/src/assets/styles/base.css
@@ -131,6 +131,23 @@ a:hover {
   padding-block: 2rem 3.5rem;
 }
 
+/* Anchor targets sit under the sticky header unless we reserve room for it,
+   which would hide the category chips when jumping to #crafts. */
+#crafts,
+#reviews,
+#main-content {
+  scroll-margin-top: 4.5rem;
+}
+
+/* the header stacks brand + search on small screens, so it needs more room */
+@media (max-width: 720px) {
+  #crafts,
+  #reviews,
+  #main-content {
+    scroll-margin-top: 8.75rem;
+  }
+}
+
 @media (max-width: 640px) {
   .container {
     width: calc(100% - 2rem);

--- a/frontend/src/assets/styles/chrome.css
+++ b/frontend/src/assets/styles/chrome.css
@@ -465,6 +465,20 @@
   white-space: nowrap;
 }
 
+.site-footer__links {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  margin: 0.4rem 0 0;
+}
+
+.site-footer__links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 .site-footer__meta svg {
   vertical-align: -2px;
   margin-right: 0.2rem;
@@ -473,5 +487,9 @@
 @media (max-width: 640px) {
   .site-footer__meta {
     text-align: left;
+  }
+
+  .site-footer__links {
+    justify-content: flex-start;
   }
 }

--- a/frontend/src/assets/styles/components.css
+++ b/frontend/src/assets/styles/components.css
@@ -88,6 +88,189 @@
   color: var(--rogan);
 }
 
+/* product card media, tags and quick actions */
+
+.product-card__media {
+  position: relative;
+}
+
+.tag {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.6rem;
+  z-index: 2;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: var(--card);
+  color: var(--ink);
+  box-shadow: 0 1px 3px rgba(43, 32, 19, 0.2);
+}
+
+.tag--low {
+  background: var(--saffron);
+  color: #fff;
+}
+
+.tag--out {
+  background: var(--rogan);
+  color: #fff;
+}
+
+.tag--top {
+  background: var(--deodar);
+  color: var(--gold);
+}
+
+.save-btn {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  z-index: 2;
+  width: 2.1rem;
+  height: 2.1rem;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 253, 247, 0.92);
+  color: var(--reed);
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(43, 32, 19, 0.22);
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+
+.save-btn:hover {
+  transform: scale(1.09);
+  color: var(--rogan);
+}
+
+.save-btn.is-saved {
+  color: var(--rogan);
+}
+
+.product-card__foot {
+  margin-top: auto;
+  padding-top: 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.quick-add {
+  flex-shrink: 0;
+}
+
+.btn.is-saved {
+  border-color: var(--rogan);
+  color: var(--rogan);
+}
+
+/* ---------- skeletons ---------- */
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--line-soft) 25%,
+    #f6f0e2 37%,
+    var(--line-soft) 63%
+  );
+  background-size: 400% 100%;
+  animation: skeleton-sweep 1.4s ease infinite;
+  border-radius: var(--radius-s);
+}
+
+.skeleton__media {
+  aspect-ratio: 4 / 3;
+  border-radius: 0;
+}
+
+.skeleton__line {
+  height: 0.72rem;
+  margin-bottom: 0.55rem;
+}
+
+.skeleton__line--short {
+  width: 45%;
+}
+
+.skeleton__line--mid {
+  width: 70%;
+}
+
+.skeleton-card:hover {
+  transform: none;
+  box-shadow: var(--shadow-card);
+}
+
+@keyframes skeleton-sweep {
+  from {
+    background-position: 100% 50%;
+  }
+  to {
+    background-position: 0 50%;
+  }
+}
+
+/* ---------- breadcrumbs ---------- */
+
+.breadcrumbs {
+  margin-bottom: 1.25rem;
+}
+
+.breadcrumbs ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.85rem;
+  color: var(--reed);
+}
+
+.breadcrumbs li + li::before {
+  content: '/';
+  margin-right: 0.4rem;
+  color: var(--line);
+}
+
+.breadcrumbs a {
+  color: var(--ink-soft);
+  font-weight: 600;
+}
+
+.breadcrumbs a:hover {
+  color: var(--saffron-deep);
+}
+
+/* ---------- empty states ---------- */
+
+.empty-state {
+  text-align: center;
+  padding: 3.5rem 1.5rem;
+  background: var(--card);
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-l);
+}
+
+.empty-state__title {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.empty-state__copy {
+  color: var(--reed);
+  margin-bottom: 1.5rem;
+}
+
 /* ---------- rating ---------- */
 
 .rating {
@@ -625,6 +808,61 @@ select.field__input {
   opacity: 0.45;
   pointer-events: none;
   transition: opacity 0.15s ease;
+}
+
+/* ---------- admin toolbar ---------- */
+
+.admin-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.admin-toolbar__search {
+  flex: 1 1 240px;
+  max-width: 360px;
+  padding: 0.45rem 0.8rem;
+}
+
+.segmented {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-s);
+  overflow: hidden;
+  background: var(--card);
+}
+
+.segmented__btn {
+  border: none;
+  background: none;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+  border-right: 1px solid var(--line-soft);
+}
+
+.segmented__btn:last-child {
+  border-right: none;
+}
+
+.segmented__btn:hover {
+  background: var(--line-soft);
+}
+
+.segmented__btn.is-active {
+  background: var(--deodar);
+  color: var(--ivory);
+}
+
+.result-count {
+  font-size: 0.85rem;
+  color: var(--reed);
+  font-variant-numeric: tabular-nums;
 }
 
 /* ---------- admin dashboard ---------- */

--- a/frontend/src/assets/styles/screens.css
+++ b/frontend/src/assets/styles/screens.css
@@ -285,6 +285,330 @@ a.step__label:hover {
   }
 }
 
+.product-detail__ratinglink {
+  display: inline-block;
+  text-decoration: none;
+}
+
+.product-detail__ratinglink:hover {
+  text-decoration: none;
+  opacity: 0.85;
+}
+
+.buy-box__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.buy-box__actions .btn {
+  flex: 1 1 auto;
+}
+
+.buy-box__assurances {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--reed);
+}
+
+.buy-box__assurances li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.buy-box__assurances svg {
+  color: var(--moss);
+  flex-shrink: 0;
+}
+
+/* sticky buy bar — mobile only */
+.buy-bar {
+  display: none;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 60;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.7rem 1rem;
+  background: var(--card);
+  border-top: 1px solid var(--line);
+  box-shadow: 0 -4px 18px -8px rgba(43, 32, 19, 0.35);
+}
+
+.buy-bar__price {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.buy-bar .btn {
+  flex: 1 1 auto;
+  max-width: 60%;
+}
+
+@media (max-width: 820px) {
+  .buy-bar {
+    display: flex;
+  }
+
+  /* keep the footer clear of the fixed bar */
+  .site-footer {
+    padding-bottom: 4rem;
+  }
+}
+
+/* ---------- rating breakdown ---------- */
+
+.rating-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: center;
+  padding: 1.25rem 1.4rem;
+  background: var(--card);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-m);
+  margin-bottom: 1.5rem;
+}
+
+.rating-breakdown__score {
+  text-align: center;
+}
+
+.rating-breakdown__number {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 2.4rem;
+  font-weight: 600;
+  line-height: 1;
+  margin-bottom: 0.3rem;
+}
+
+.rating-breakdown__count {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.82rem;
+  color: var(--reed);
+}
+
+.rating-breakdown__bars {
+  flex: 1 1 240px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.rating-breakdown__bars li {
+  display: grid;
+  grid-template-columns: 2rem 1fr 1.5rem;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+  color: var(--reed);
+}
+
+.rating-breakdown__track {
+  height: 7px;
+  border-radius: 999px;
+  background: var(--line-soft);
+  overflow: hidden;
+}
+
+.rating-breakdown__fill {
+  display: block;
+  height: 100%;
+  background: var(--gold);
+  border-radius: 999px;
+}
+
+.rating-breakdown__pct {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.reviews__sort {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 1rem;
+}
+
+.reviews__sort .field__input {
+  padding: 0.4rem 0.7rem;
+  font-size: 0.9rem;
+}
+
+.review-card__avatar {
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  background: var(--deodar);
+  color: var(--ivory);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+/* ---------- product rail ---------- */
+
+.rail {
+  margin-top: 3rem;
+}
+
+.rail__track {
+  display: grid;
+  grid-auto-flow: column;
+  /* fixed-width cards so a two-item rail doesn't stretch to full width */
+  grid-auto-columns: 190px;
+  justify-content: start;
+  gap: 1rem;
+  overflow-x: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.5rem;
+  scroll-snap-type: x mandatory;
+}
+
+@media (max-width: 480px) {
+  .rail__track {
+    grid-auto-columns: 158px;
+  }
+}
+
+.rail__item {
+  scroll-snap-align: start;
+}
+
+.rail__card {
+  display: block;
+  background: var(--card);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-m);
+  overflow: hidden;
+  text-decoration: none;
+  color: var(--ink);
+  height: 100%;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.rail__card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-card);
+  text-decoration: none;
+}
+
+.rail__card img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.rail__name,
+.rail__price {
+  display: block;
+  padding-inline: 0.75rem;
+}
+
+.rail__name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-top: 0.6rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.rail__card .rating {
+  padding-inline: 0.75rem;
+  margin-block: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.rail__price {
+  font-weight: 700;
+  padding-bottom: 0.9rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- order timeline ---------- */
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.timeline__step {
+  display: grid;
+  grid-template-columns: 1.6rem 1fr;
+  grid-template-areas:
+    'dot label'
+    'dot detail';
+  gap: 0 0.85rem;
+  position: relative;
+}
+
+.timeline__step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: 0.72rem;
+  top: 1.7rem;
+  bottom: -1.1rem;
+  width: 2px;
+  background: var(--line);
+}
+
+.timeline__step.is-done:not(:last-child)::after {
+  background: var(--moss);
+}
+
+.timeline__dot {
+  grid-area: dot;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  border: 2px solid var(--line);
+  background: var(--card);
+  display: grid;
+  place-items: center;
+  color: #fff;
+  z-index: 1;
+}
+
+.timeline__step.is-done .timeline__dot {
+  background: var(--moss);
+  border-color: var(--moss);
+}
+
+.timeline__label {
+  grid-area: label;
+  font-weight: 700;
+  line-height: 1.5rem;
+}
+
+.timeline__detail {
+  grid-area: detail;
+  font-size: 0.85rem;
+  color: var(--reed);
+}
+
 /* reviews */
 .reviews {
   max-width: 720px;

--- a/frontend/src/components/Breadcrumbs.jsx
+++ b/frontend/src/components/Breadcrumbs.jsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+
+// trail: [{ label, to }] — the last entry renders as plain text (current page)
+const Breadcrumbs = ({ trail }) => (
+  <nav className='breadcrumbs' aria-label='Breadcrumb'>
+    <ol>
+      {trail.map((crumb, i) => {
+        const isLast = i === trail.length - 1;
+        return (
+          <li key={crumb.label}>
+            {isLast || !crumb.to ? (
+              <span aria-current={isLast ? 'page' : undefined}>
+                {crumb.label}
+              </span>
+            ) : (
+              <Link to={crumb.to}>{crumb.label}</Link>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  </nav>
+);
+
+export default Breadcrumbs;

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,4 +1,4 @@
-import { FaGithub } from 'react-icons/fa';
+import { FaGithub, FaLinkedin } from 'react-icons/fa';
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();
@@ -14,22 +14,28 @@ const Footer = () => {
           </p>
         </div>
         <div className='site-footer__meta'>
-          <p style={{ margin: 0 }}>
-            A portfolio project by{' '}
+          <p style={{ margin: 0 }}>A portfolio project by Auqid Irfan</p>
+          <p className='site-footer__links'>
+            <a
+              href='https://www.linkedin.com/in/auqidirfan/'
+              target='_blank'
+              rel='noreferrer'
+            >
+              <FaLinkedin aria-hidden='true' /> LinkedIn
+            </a>
             <a
               href='https://github.com/auqid'
               target='_blank'
               rel='noreferrer'
             >
-              <FaGithub aria-hidden='true' /> auqid
-            </a>{' '}
-            ·{' '}
+              <FaGithub aria-hidden='true' /> GitHub
+            </a>
             <a
               href='https://github.com/auqid/azshop'
               target='_blank'
               rel='noreferrer'
             >
-              source code
+              Source code
             </a>
           </p>
           <p style={{ margin: '0.25rem 0 0' }}>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -6,6 +6,7 @@ import {
   FaUserCircle,
   FaChevronDown,
   FaSlidersH,
+  FaHeart,
 } from 'react-icons/fa';
 import { useLogoutMutation } from '../slices/usersApiSlice';
 import { logout } from '../slices/authSlice';
@@ -48,6 +49,7 @@ const Menu = ({ label, children }) => {
 
 const Header = () => {
   const { cartItems } = useSelector((state) => state.cart);
+  const { items: savedItems } = useSelector((state) => state.wishlist);
   const { userInfo } = useSelector((state) => state.auth);
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -65,6 +67,7 @@ const Header = () => {
   };
 
   const cartCount = cartItems.reduce((a, c) => a + c.qty, 0);
+  const savedCount = savedItems.length;
 
   return (
     <header className='site-header'>
@@ -80,6 +83,12 @@ const Header = () => {
         <SearchBox />
 
         <nav className='site-nav'>
+          <Link to='/wishlist' className='nav-link' aria-label='Saved items'>
+            <FaHeart />
+            <span className='nav-text'>Saved</span>
+            {savedCount > 0 && <span className='cart-badge'>{savedCount}</span>}
+          </Link>
+
           <Link to='/cart' className='nav-link' aria-label='Cart'>
             <FaShoppingBasket />
             <span className='nav-text'>Cart</span>

--- a/frontend/src/components/OrderTimeline.jsx
+++ b/frontend/src/components/OrderTimeline.jsx
@@ -1,0 +1,50 @@
+import { FaCheck } from 'react-icons/fa';
+import { formatDate } from '../utils/formatters';
+
+// Visual progress of an order: placed -> paid -> delivered.
+const OrderTimeline = ({ order }) => {
+  const isCod = order.paymentMethod === 'Cash on Delivery';
+
+  const steps = [
+    {
+      label: 'Order placed',
+      detail: formatDate(order.createdAt),
+      done: true,
+    },
+    {
+      label: order.isPaid ? 'Payment received' : 'Payment pending',
+      detail: order.isPaid
+        ? formatDate(order.paidAt)
+        : isCod
+        ? 'Collected on delivery'
+        : 'Awaiting payment',
+      done: order.isPaid,
+    },
+    {
+      label: order.isDelivered ? 'Delivered' : 'On its way',
+      detail: order.isDelivered
+        ? formatDate(order.deliveredAt)
+        : 'Ships from Srinagar',
+      done: order.isDelivered,
+    },
+  ];
+
+  return (
+    <ol className='timeline'>
+      {steps.map((step) => (
+        <li
+          key={step.label}
+          className={step.done ? 'timeline__step is-done' : 'timeline__step'}
+        >
+          <span className='timeline__dot' aria-hidden='true'>
+            {step.done && <FaCheck size={10} />}
+          </span>
+          <span className='timeline__label'>{step.label}</span>
+          <span className='timeline__detail'>{step.detail}</span>
+        </li>
+      ))}
+    </ol>
+  );
+};
+
+export default OrderTimeline;

--- a/frontend/src/components/Paginate.jsx
+++ b/frontend/src/components/Paginate.jsx
@@ -6,6 +6,7 @@ const Paginate = ({
   isAdmin = false,
   keyword = '',
   category = '',
+  searchAll = false,
 }) => {
   const { search } = useLocation();
 
@@ -16,6 +17,8 @@ const Paginate = ({
       ? `/admin/productlist/${p}`
       : keyword
       ? `/search/${keyword}/page/${p}`
+      : searchAll
+      ? `/search/page/${p}`
       : category
       ? `/category/${encodeURIComponent(category)}/page/${p}`
       : `/page/${p}`;

--- a/frontend/src/components/Product.jsx
+++ b/frontend/src/components/Product.jsx
@@ -1,20 +1,65 @@
 import { Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { FaHeart, FaRegHeart, FaPlus } from 'react-icons/fa';
+import { toast } from 'react-toastify';
 import Rating from './Rating';
+import { addToCart } from '../slices/cartSlice';
+import { toggleWishlist } from '../slices/wishlistSlice';
 import { formatINR } from '../utils/formatters';
 
+const LOW_STOCK_AT = 5;
+
 const Product = ({ product }) => {
+  const dispatch = useDispatch();
+  const saved = useSelector((state) =>
+    state.wishlist.items.some((x) => x._id === product._id)
+  );
+
+  const outOfStock = product.countInStock === 0;
+
+  const addHandler = () => {
+    dispatch(addToCart({ ...product, qty: 1 }));
+    toast.success(`${product.name} added to cart`);
+  };
+
+  const wishlistHandler = () => {
+    dispatch(toggleWishlist(product));
+    toast.info(saved ? 'Removed from saved items' : 'Saved for later');
+  };
+
   return (
     <article className='product-card'>
-      <Link to={`/product/${product._id}`} className='product-card__image'>
-        <img
-          src={product.image}
-          alt={product.name}
-          loading='lazy'
-          decoding='async'
-          width='800'
-          height='600'
-        />
-      </Link>
+      <div className='product-card__media'>
+        <Link to={`/product/${product._id}`} className='product-card__image'>
+          <img
+            src={product.image}
+            alt={product.name}
+            loading='lazy'
+            decoding='async'
+            width='800'
+            height='600'
+          />
+        </Link>
+
+        {outOfStock ? (
+          <span className='tag tag--out'>Sold out</span>
+        ) : product.countInStock <= LOW_STOCK_AT ? (
+          <span className='tag tag--low'>Only {product.countInStock} left</span>
+        ) : product.rating >= 4.7 && product.numReviews >= 3 ? (
+          <span className='tag tag--top'>Top rated</span>
+        ) : null}
+
+        <button
+          type='button'
+          className={saved ? 'save-btn is-saved' : 'save-btn'}
+          onClick={wishlistHandler}
+          aria-pressed={saved}
+          aria-label={saved ? `Remove ${product.name} from saved` : `Save ${product.name}`}
+          title={saved ? 'Remove from saved' : 'Save for later'}
+        >
+          {saved ? <FaHeart /> : <FaRegHeart />}
+        </button>
+      </div>
 
       <div className='product-card__body'>
         <div className='product-card__brand'>{product.brand}</div>
@@ -27,11 +72,20 @@ const Product = ({ product }) => {
             product.numReviews === 1 ? '' : 's'
           }`}
         />
-        <div className='product-card__price'>
-          {formatINR(product.price)}
-          {product.countInStock === 0 && (
-            <span className='product-card__flag'> · Out of stock</span>
-          )}
+
+        <div className='product-card__foot'>
+          <span className='product-card__price'>
+            {formatINR(product.price)}
+          </span>
+          <button
+            type='button'
+            className='btn btn--sm quick-add'
+            onClick={addHandler}
+            disabled={outOfStock}
+            aria-label={`Add ${product.name} to cart`}
+          >
+            <FaPlus size={11} /> Add
+          </button>
         </div>
       </div>
     </article>

--- a/frontend/src/components/ProductGridSkeleton.jsx
+++ b/frontend/src/components/ProductGridSkeleton.jsx
@@ -1,0 +1,19 @@
+// Placeholder cards shown while the first page of products loads. Matching the
+// real card's shape keeps the layout from jumping when data arrives.
+const ProductGridSkeleton = ({ count = 8 }) => (
+  <div className='product-grid' aria-hidden='true'>
+    {Array.from({ length: count }, (_, i) => (
+      <article key={i} className='product-card skeleton-card'>
+        <div className='skeleton skeleton__media'></div>
+        <div className='product-card__body'>
+          <div className='skeleton skeleton__line skeleton__line--short'></div>
+          <div className='skeleton skeleton__line'></div>
+          <div className='skeleton skeleton__line skeleton__line--mid'></div>
+          <div className='skeleton skeleton__line skeleton__line--short'></div>
+        </div>
+      </article>
+    ))}
+  </div>
+);
+
+export default ProductGridSkeleton;

--- a/frontend/src/components/ProductRail.jsx
+++ b/frontend/src/components/ProductRail.jsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom';
+import Rating from './Rating';
+import { formatINR } from '../utils/formatters';
+
+// Compact horizontal strip of products — used for related and recently viewed.
+const ProductRail = ({ title, products, emptyHint }) => {
+  if (!products || products.length === 0) return emptyHint || null;
+
+  return (
+    <section className='rail'>
+      <div className='section-head'>
+        <h2>{title}</h2>
+      </div>
+      <ul className='rail__track'>
+        {products.map((product) => (
+          <li key={product._id} className='rail__item'>
+            <Link to={`/product/${product._id}`} className='rail__card'>
+              <img
+                src={product.image}
+                alt={product.name}
+                loading='lazy'
+                decoding='async'
+              />
+              <span className='rail__name'>{product.name}</span>
+              <Rating value={product.rating} />
+              <span className='rail__price'>{formatINR(product.price)}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default ProductRail;

--- a/frontend/src/components/RatingBreakdown.jsx
+++ b/frontend/src/components/RatingBreakdown.jsx
@@ -1,0 +1,43 @@
+import Rating from './Rating';
+
+// Histogram of how many reviews gave each star count.
+const RatingBreakdown = ({ reviews, rating }) => {
+  if (!reviews || reviews.length === 0) return null;
+
+  const counts = [5, 4, 3, 2, 1].map((stars) => ({
+    stars,
+    count: reviews.filter((r) => Math.round(r.rating) === stars).length,
+  }));
+
+  return (
+    <div className='rating-breakdown'>
+      <div className='rating-breakdown__score'>
+        <span className='rating-breakdown__number'>{rating.toFixed(1)}</span>
+        <Rating value={rating} />
+        <span className='rating-breakdown__count'>
+          {reviews.length} review{reviews.length === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      <ul className='rating-breakdown__bars'>
+        {counts.map(({ stars, count }) => {
+          const pct = Math.round((count / reviews.length) * 100);
+          return (
+            <li key={stars}>
+              <span className='rating-breakdown__label'>{stars}★</span>
+              <span className='rating-breakdown__track'>
+                <span
+                  className='rating-breakdown__fill'
+                  style={{ width: `${pct}%` }}
+                ></span>
+              </span>
+              <span className='rating-breakdown__pct'>{count}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default RatingBreakdown;

--- a/frontend/src/components/ScrollToTop.jsx
+++ b/frontend/src/components/ScrollToTop.jsx
@@ -1,13 +1,46 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
+// Every way of browsing the catalog: all crafts, a category, a search, and the
+// paginated variants of each.
+const CATALOG_PATH =
+  /^\/(page\/\d+|category\/[^/]+(\/page\/\d+)?|search(\/[^/]+)?(\/page\/\d+)?)?$/;
+
 // React Router keeps the scroll position across navigations, which lands you
-// mid-page after following a link. Reset on path change, but leave query-only
-// changes (filters, sorting) alone so the grid doesn't jump under you.
+// mid-page after following a link. Reset on path change — except when moving
+// around inside the catalog (next page, another category), where being thrown
+// back up to the hero loses your place. There we only scroll far enough to put
+// the top of the results under the header, and only if you were below it.
 const ScrollToTop = () => {
   const { pathname } = useLocation();
+  const previousPath = useRef(pathname);
 
   useEffect(() => {
+    const from = previousPath.current;
+    previousPath.current = pathname;
+
+    if (from === pathname) return;
+
+    const withinCatalog =
+      CATALOG_PATH.test(from) && CATALOG_PATH.test(pathname);
+
+    if (withinCatalog) {
+      const catalog = document.getElementById('crafts');
+      if (catalog) {
+        const header = document.querySelector('.site-header');
+        const offset = (header?.offsetHeight || 0) + 12;
+        const resultsTop =
+          catalog.getBoundingClientRect().top + window.scrollY - offset;
+
+        // Only pull up if they're already past the start of the results;
+        // if the hero is still on screen, leave the page where it is.
+        if (window.scrollY > resultsTop) {
+          window.scrollTo({ top: resultsTop, left: 0, behavior: 'instant' });
+        }
+        return;
+      }
+    }
+
     window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
   }, [pathname]);
 

--- a/frontend/src/components/SearchBox.jsx
+++ b/frontend/src/components/SearchBox.jsx
@@ -9,11 +9,9 @@ const SearchBox = () => {
 
   const submitHandler = (e) => {
     e.preventDefault();
-    if (keyword.trim()) {
-      navigate(`/search/${keyword.trim()}`);
-    } else {
-      navigate('/');
-    }
+    // An empty search still opens the results page, listing everything —
+    // more useful than silently doing nothing.
+    navigate(keyword.trim() ? `/search/${keyword.trim()}` : '/search');
   };
 
   return (

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -15,6 +15,7 @@ import store from './store';
 import HomeScreen from './screens/HomeScreen';
 import ProductScreen from './screens/ProductScreen';
 import CartScreen from './screens/CartScreen';
+import WishlistScreen from './screens/WishlistScreen';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
 import ShippingScreen from './screens/ShippingScreen';
@@ -51,6 +52,8 @@ const router = createBrowserRouter(
   createRoutesFromElements(
     <Route path='/' element={<App />}>
       <Route index={true} path='/' element={<HomeScreen />} />
+      <Route path='/search' element={<HomeScreen />} />
+      <Route path='/search/page/:pageNumber' element={<HomeScreen />} />
       <Route path='/search/:keyword' element={<HomeScreen />} />
       <Route path='/page/:pageNumber' element={<HomeScreen />} />
       <Route
@@ -64,6 +67,7 @@ const router = createBrowserRouter(
       />
       <Route path='/product/:id' element={<ProductScreen />} />
       <Route path='/cart' element={<CartScreen />} />
+      <Route path='/wishlist' element={<WishlistScreen />} />
       <Route path='/login' element={<LoginScreen />} />
       <Route path='/register' element={<RegisterScreen />} />
 

--- a/frontend/src/screens/HomeScreen.jsx
+++ b/frontend/src/screens/HomeScreen.jsx
@@ -1,5 +1,6 @@
 import {
   Link,
+  useLocation,
   useNavigate,
   useParams,
   useSearchParams,
@@ -7,9 +8,9 @@ import {
 import { FaArrowLeft } from 'react-icons/fa';
 import { useGetProductsQuery } from '../slices/productsApiSlice';
 import Product from '../components/Product';
-import Loader from '../components/Loader';
 import Message from '../components/Message';
 import Paginate from '../components/Paginate';
+import ProductGridSkeleton from '../components/ProductGridSkeleton';
 import CategoryNav from '../components/CategoryNav';
 import FilterBar from '../components/FilterBar';
 import Hero from '../components/Hero';
@@ -20,6 +21,10 @@ const HomeScreen = () => {
   const { pageNumber, keyword, category } = useParams();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  // /search with no keyword lists the whole catalogue in results form
+  const isSearch = pathname.startsWith('/search');
 
   const filters = {
     sort: searchParams.get('sort') || '',
@@ -46,6 +51,8 @@ const HomeScreen = () => {
     });
     const base = keyword
       ? `/search/${keyword}`
+      : isSearch
+      ? '/search'
       : category
       ? `/category/${encodeURIComponent(category)}`
       : '/';
@@ -56,15 +63,17 @@ const HomeScreen = () => {
     ? `Results for “${keyword}”`
     : category
     ? category
+    : isSearch
+    ? 'Everything we make'
     : 'The crafts';
 
   return (
     <>
       <Meta title={category ? `${category} — Nargis` : undefined} />
-      {!keyword && <Hero />}
+      {!isSearch && <Hero />}
 
       <div className='container page' id='crafts'>
-        {keyword && (
+        {isSearch && (
           <Link to='/' className='back-link'>
             <FaArrowLeft /> Back to all crafts
           </Link>
@@ -75,7 +84,12 @@ const HomeScreen = () => {
 
         <div className='catalog'>
           {isLoading ? (
-            <Loader />
+            <>
+              <div className='section-head'>
+                <h2>{heading}</h2>
+              </div>
+              <ProductGridSkeleton />
+            </>
           ) : error ? (
             <Message variant='danger'>
               {error?.data?.message || error.error}
@@ -108,13 +122,14 @@ const HomeScreen = () => {
                 page={data.page}
                 keyword={keyword ? keyword : ''}
                 category={category ? category : ''}
+                searchAll={isSearch && !keyword}
               />
             </>
           )}
         </div>
       </div>
 
-      {!keyword && !category && <PoemBand />}
+      {!isSearch && !category && <PoemBand />}
     </>
   );
 };

--- a/frontend/src/screens/OrderScreen.jsx
+++ b/frontend/src/screens/OrderScreen.jsx
@@ -15,7 +15,7 @@ import {
 } from '../slices/ordersApiSlice';
 import OrderLineItem from '../components/OrderLineItem';
 import OrderSummary from '../components/OrderSummary';
-import { formatDate } from '../utils/formatters';
+import OrderTimeline from '../components/OrderTimeline';
 
 const OrderScreen = () => {
   const { id: orderId } = useParams();
@@ -126,6 +126,11 @@ const OrderScreen = () => {
       <div className='checkout-grid'>
         <div className='panel'>
           <div className='panel__section'>
+            <h2>Progress</h2>
+            <OrderTimeline order={order} />
+          </div>
+
+          <div className='panel__section'>
             <h2>Shipping</h2>
             <p style={{ margin: '0 0 0.35rem' }}>
               <strong>{order.user.name}</strong> ·{' '}
@@ -136,29 +141,12 @@ const OrderScreen = () => {
               {order.shippingAddress.postalCode},{' '}
               {order.shippingAddress.country}
             </p>
-            {order.isDelivered ? (
-              <Message variant='success'>
-                Delivered on {formatDate(order.deliveredAt)}
-              </Message>
-            ) : (
-              <Message>Not yet delivered</Message>
-            )}
           </div>
 
+          {/* Paid/delivered status lives in the timeline above */}
           <div className='panel__section'>
             <h2>Payment</h2>
             <p style={{ margin: 0 }}>{order.paymentMethod}</p>
-            {order.isPaid ? (
-              <Message variant='success'>
-                Paid on {formatDate(order.paidAt)}
-              </Message>
-            ) : (
-              <Message>
-                {order.paymentMethod === 'Cash on Delivery'
-                  ? 'Payment will be collected when the order arrives.'
-                  : 'Not yet paid'}
-              </Message>
-            )}
           </div>
 
           <div className='panel__section'>

--- a/frontend/src/screens/ProductScreen.jsx
+++ b/frontend/src/screens/ProductScreen.jsx
@@ -1,17 +1,26 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { FaArrowLeft } from 'react-icons/fa';
+import { FaHeart, FaRegHeart, FaTruck, FaMoneyBillWave } from 'react-icons/fa';
 import { toast } from 'react-toastify';
 import {
   useGetProductDetailsQuery,
+  useGetProductsQuery,
   useCreateReviewMutation,
 } from '../slices/productsApiSlice';
 import Rating from '../components/Rating';
+import RatingBreakdown from '../components/RatingBreakdown';
+import Breadcrumbs from '../components/Breadcrumbs';
+import ProductRail from '../components/ProductRail';
 import Loader from '../components/Loader';
 import Message from '../components/Message';
 import Meta from '../components/Meta';
 import { addToCart } from '../slices/cartSlice';
+import { toggleWishlist } from '../slices/wishlistSlice';
+import {
+  getRecentlyViewed,
+  recordProductView,
+} from '../utils/recentlyViewed';
 import { formatINR, formatDate } from '../utils/formatters';
 
 const ProductScreen = () => {
@@ -23,6 +32,7 @@ const ProductScreen = () => {
   const [qty, setQty] = useState(1);
   const [rating, setRating] = useState('');
   const [comment, setComment] = useState('');
+  const [reviewSort, setReviewSort] = useState('recent');
 
   const {
     data: product,
@@ -32,18 +42,61 @@ const ProductScreen = () => {
   } = useGetProductDetailsQuery(productId);
 
   const { userInfo } = useSelector((state) => state.auth);
+  const saved = useSelector((state) =>
+    state.wishlist.items.some((x) => x._id === productId)
+  );
 
   const [createReview, { isLoading: loadingProductReview }] =
     useCreateReviewMutation();
 
+  // Others in the same category, minus the product being viewed
+  const { data: relatedData } = useGetProductsQuery(
+    { category: product?.category },
+    { skip: !product?.category }
+  );
+
+  const related = (relatedData?.products || [])
+    .filter((p) => p._id !== productId)
+    .slice(0, 6);
+
+  const recentlyViewed = useMemo(
+    () => getRecentlyViewed(productId),
+    [productId]
+  );
+
+  useEffect(() => {
+    if (product) recordProductView(product);
+  }, [product]);
+
+  // Reset the quantity picker when navigating straight from one product to
+  // another (the component stays mounted, so this can't be initial state).
+  const [qtyOwner, setQtyOwner] = useState(productId);
+  if (qtyOwner !== productId) {
+    setQtyOwner(productId);
+    setQty(1);
+  }
+
+  const reviews = product?.reviews;
+  const sortedReviews = useMemo(() => {
+    if (!reviews) return [];
+    const copy = [...reviews];
+    if (reviewSort === 'high') return copy.sort((a, b) => b.rating - a.rating);
+    if (reviewSort === 'low') return copy.sort((a, b) => a.rating - b.rating);
+    return copy.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  }, [reviews, reviewSort]);
+
   const addToCartHandler = () => {
+    dispatch(addToCart({ ...product, qty }));
+    toast.success(`${product.name} added to cart`);
+  };
+
+  const buyNowHandler = () => {
     dispatch(addToCart({ ...product, qty }));
     navigate('/cart');
   };
 
   const submitHandler = async (e) => {
     e.preventDefault();
-
     try {
       await createReview({ productId, rating, comment }).unwrap();
       refetch();
@@ -55,181 +108,252 @@ const ProductScreen = () => {
     }
   };
 
-  return (
-    <div className='container page'>
-      <Link to='/' className='back-link'>
-        <FaArrowLeft /> Back to all crafts
-      </Link>
-
-      {isLoading ? (
+  if (isLoading) {
+    return (
+      <div className='container page'>
         <Loader />
-      ) : error ? (
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className='container page'>
         <Message variant='danger'>
           {error?.data?.message || error.error}
         </Message>
-      ) : (
-        <>
-          <Meta title={product.name} description={product.description} />
+      </div>
+    );
+  }
 
-          <div className='product-detail'>
-            <div className='product-detail__image'>
-              <img src={product.image} alt={product.name} />
-            </div>
+  const outOfStock = product.countInStock === 0;
 
-            <div>
-              <div className='eyebrow product-detail__brand'>
-                {product.brand} ·{' '}
-                <Link
-                  to={`/category/${encodeURIComponent(product.category)}`}
-                  style={{ color: 'inherit' }}
-                >
-                  {product.category}
-                </Link>
-              </div>
-              <h1>{product.name}</h1>
-              <Rating
-                value={product.rating}
-                text={`${product.numReviews} review${
-                  product.numReviews === 1 ? '' : 's'
-                }`}
-              />
-              <div className='product-detail__price'>
-                {formatINR(product.price)}
-              </div>
-              <p className='product-detail__desc'>{product.description}</p>
+  return (
+    <div className='container page'>
+      <Meta title={product.name} description={product.description} />
 
-              <div className='buy-box'>
-                <div className='buy-box__row'>
-                  <span
-                    className={
-                      product.countInStock > 0
-                        ? 'stock-flag stock-flag--in'
-                        : 'stock-flag stock-flag--out'
-                    }
-                  >
-                    {product.countInStock > 0
-                      ? `In stock · ${product.countInStock} left`
-                      : 'Out of stock'}
-                  </span>
+      <Breadcrumbs
+        trail={[
+          { label: 'Crafts', to: '/' },
+          {
+            label: product.category,
+            to: `/category/${encodeURIComponent(product.category)}`,
+          },
+          { label: product.name },
+        ]}
+      />
 
-                  {product.countInStock > 0 && (
-                    <label>
-                      <span className='field__label'>Quantity</span>
-                      <select
-                        className='field__input qty-select'
-                        value={qty}
-                        onChange={(e) => setQty(Number(e.target.value))}
-                      >
-                        {[...Array(product.countInStock).keys()].map((x) => (
-                          <option key={x + 1} value={x + 1}>
-                            {x + 1}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                  )}
-                </div>
+      <div className='product-detail'>
+        <div className='product-detail__image'>
+          <img src={product.image} alt={product.name} width='800' height='600' />
+        </div>
 
-                <button
-                  type='button'
-                  className='btn btn--block'
-                  disabled={product.countInStock === 0}
-                  onClick={addToCartHandler}
-                >
-                  Add to cart
-                </button>
-                <p
-                  style={{
-                    margin: '0.75rem 0 0',
-                    fontSize: '0.85rem',
-                    color: 'var(--reed)',
-                  }}
-                >
-                  Free shipping on orders over ₹2,000 · Cash on Delivery
-                  available
-                </p>
-              </div>
-            </div>
+        <div>
+          <div className='eyebrow product-detail__brand'>{product.brand}</div>
+          <h1>{product.name}</h1>
+
+          <a href='#reviews' className='product-detail__ratinglink'>
+            <Rating
+              value={product.rating}
+              text={`${product.numReviews} review${
+                product.numReviews === 1 ? '' : 's'
+              }`}
+            />
+          </a>
+
+          <div className='product-detail__price'>
+            {formatINR(product.price)}
           </div>
+          <p className='product-detail__desc'>{product.description}</p>
 
-          <section className='reviews'>
-            <div className='section-head'>
-              <h2>Reviews</h2>
-            </div>
+          <div className='buy-box'>
+            <div className='buy-box__row'>
+              <span
+                className={
+                  outOfStock
+                    ? 'stock-flag stock-flag--out'
+                    : 'stock-flag stock-flag--in'
+                }
+              >
+                {outOfStock
+                  ? 'Out of stock'
+                  : `In stock · ${product.countInStock} left`}
+              </span>
 
-            {product.reviews.length === 0 && (
-              <Message>No reviews yet. Be the first to write one.</Message>
-            )}
-
-            {product.reviews.map((review) => (
-              <article key={review._id} className='review-card'>
-                <div className='review-card__head'>
-                  <span className='review-card__name'>{review.name}</span>
-                  <Rating value={review.rating} />
-                  <span className='review-card__date'>
-                    {formatDate(review.createdAt)}
-                  </span>
-                </div>
-                <p>{review.comment}</p>
-              </article>
-            ))}
-
-            <div style={{ marginTop: '2rem' }}>
-              <h3>Write a review</h3>
-
-              {loadingProductReview && <Loader small />}
-
-              {userInfo ? (
-                <form onSubmit={submitHandler}>
-                  <div className='field'>
-                    <label className='field__label' htmlFor='rating'>
-                      Rating
-                    </label>
-                    <select
-                      id='rating'
-                      className='field__input'
-                      required
-                      value={rating}
-                      onChange={(e) => setRating(e.target.value)}
-                    >
-                      <option value=''>Choose a rating…</option>
-                      <option value='1'>1 — Poor</option>
-                      <option value='2'>2 — Fair</option>
-                      <option value='3'>3 — Good</option>
-                      <option value='4'>4 — Very good</option>
-                      <option value='5'>5 — Excellent</option>
-                    </select>
-                  </div>
-                  <div className='field'>
-                    <label className='field__label' htmlFor='comment'>
-                      Comment
-                    </label>
-                    <textarea
-                      id='comment'
-                      className='field__input'
-                      rows='3'
-                      required
-                      value={comment}
-                      onChange={(e) => setComment(e.target.value)}
-                    ></textarea>
-                  </div>
-                  <button
-                    type='submit'
-                    className='btn'
-                    disabled={loadingProductReview}
+              {!outOfStock && (
+                <label>
+                  <span className='field__label'>Quantity</span>
+                  <select
+                    className='field__input qty-select'
+                    value={qty}
+                    onChange={(e) => setQty(Number(e.target.value))}
                   >
-                    Post review
-                  </button>
-                </form>
-              ) : (
-                <Message>
-                  <Link to='/login'>Sign in</Link> to write a review.
-                </Message>
+                    {[...Array(product.countInStock).keys()].map((x) => (
+                      <option key={x + 1} value={x + 1}>
+                        {x + 1}
+                      </option>
+                    ))}
+                  </select>
+                </label>
               )}
             </div>
-          </section>
-        </>
-      )}
+
+            <div className='buy-box__actions'>
+              <button
+                type='button'
+                className='btn'
+                disabled={outOfStock}
+                onClick={addToCartHandler}
+              >
+                Add to cart
+              </button>
+              <button
+                type='button'
+                className='btn btn--dark'
+                disabled={outOfStock}
+                onClick={buyNowHandler}
+              >
+                Buy now
+              </button>
+              <button
+                type='button'
+                className={saved ? 'btn btn--ghost is-saved' : 'btn btn--ghost'}
+                onClick={() => {
+                  dispatch(toggleWishlist(product));
+                  toast.info(saved ? 'Removed from saved' : 'Saved for later');
+                }}
+                aria-pressed={saved}
+              >
+                {saved ? <FaHeart /> : <FaRegHeart />}
+                {saved ? 'Saved' : 'Save'}
+              </button>
+            </div>
+
+            <ul className='buy-box__assurances'>
+              <li>
+                <FaTruck aria-hidden='true' /> Free shipping over ₹2,000
+              </li>
+              <li>
+                <FaMoneyBillWave aria-hidden='true' /> Cash on Delivery
+                available
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <section className='reviews' id='reviews'>
+        <div className='section-head'>
+          <h2>Reviews</h2>
+        </div>
+
+        <RatingBreakdown reviews={product.reviews} rating={product.rating} />
+
+        {product.reviews.length === 0 && (
+          <Message>No reviews yet. Be the first to write one.</Message>
+        )}
+
+        {product.reviews.length > 1 && (
+          <label className='reviews__sort'>
+            <span className='field__label'>Sort reviews</span>
+            <select
+              className='field__input'
+              value={reviewSort}
+              onChange={(e) => setReviewSort(e.target.value)}
+            >
+              <option value='recent'>Most recent</option>
+              <option value='high'>Highest rated</option>
+              <option value='low'>Lowest rated</option>
+            </select>
+          </label>
+        )}
+
+        {sortedReviews.map((review) => (
+          <article key={review._id} className='review-card'>
+            <div className='review-card__head'>
+              <span className='review-card__avatar' aria-hidden='true'>
+                {review.name.charAt(0)}
+              </span>
+              <span className='review-card__name'>{review.name}</span>
+              <Rating value={review.rating} />
+              <span className='review-card__date'>
+                {formatDate(review.createdAt)}
+              </span>
+            </div>
+            <p>{review.comment}</p>
+          </article>
+        ))}
+
+        <div style={{ marginTop: '2rem' }}>
+          <h3>Write a review</h3>
+
+          {loadingProductReview && <Loader small />}
+
+          {userInfo ? (
+            <form onSubmit={submitHandler}>
+              <div className='field'>
+                <label className='field__label' htmlFor='rating'>
+                  Rating
+                </label>
+                <select
+                  id='rating'
+                  className='field__input'
+                  required
+                  value={rating}
+                  onChange={(e) => setRating(e.target.value)}
+                >
+                  <option value=''>Choose a rating…</option>
+                  <option value='1'>1 — Poor</option>
+                  <option value='2'>2 — Fair</option>
+                  <option value='3'>3 — Good</option>
+                  <option value='4'>4 — Very good</option>
+                  <option value='5'>5 — Excellent</option>
+                </select>
+              </div>
+              <div className='field'>
+                <label className='field__label' htmlFor='comment'>
+                  Comment
+                </label>
+                <textarea
+                  id='comment'
+                  className='field__input'
+                  rows='3'
+                  required
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                ></textarea>
+              </div>
+              <button
+                type='submit'
+                className='btn'
+                disabled={loadingProductReview}
+              >
+                Post review
+              </button>
+            </form>
+          ) : (
+            <Message>
+              <Link to='/login'>Sign in</Link> to write a review.
+            </Message>
+          )}
+        </div>
+      </section>
+
+      <ProductRail title={`More in ${product.category}`} products={related} />
+      <ProductRail title='Recently viewed' products={recentlyViewed} />
+
+      {/* Mobile-only sticky bar so the price and action stay reachable */}
+      <div className='buy-bar'>
+        <div className='buy-bar__price'>{formatINR(product.price)}</div>
+        <button
+          type='button'
+          className='btn'
+          disabled={outOfStock}
+          onClick={addToCartHandler}
+        >
+          {outOfStock ? 'Sold out' : 'Add to cart'}
+        </button>
+      </div>
     </div>
   );
 };

--- a/frontend/src/screens/WishlistScreen.jsx
+++ b/frontend/src/screens/WishlistScreen.jsx
@@ -1,0 +1,67 @@
+import { Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
+import Product from '../components/Product';
+import Meta from '../components/Meta';
+import { addToCart } from '../slices/cartSlice';
+import { clearWishlist } from '../slices/wishlistSlice';
+
+const WishlistScreen = () => {
+  const { items } = useSelector((state) => state.wishlist);
+  const dispatch = useDispatch();
+
+  const inStock = items.filter((item) => item.countInStock > 0);
+
+  const addAllHandler = () => {
+    inStock.forEach((item) => dispatch(addToCart({ ...item, qty: 1 })));
+    toast.success(
+      `${inStock.length} item${inStock.length === 1 ? '' : 's'} added to cart`
+    );
+  };
+
+  return (
+    <div className='container page'>
+      <Meta title='Saved items — Nargis' />
+
+      <div className='page-title-row'>
+        <h1>Saved items</h1>
+        {items.length > 0 && (
+          <div style={{ display: 'flex', gap: '0.6rem', flexWrap: 'wrap' }}>
+            {inStock.length > 0 && (
+              <button type='button' className='btn' onClick={addAllHandler}>
+                Add {inStock.length} to cart
+              </button>
+            )}
+            <button
+              type='button'
+              className='btn btn--ghost'
+              onClick={() => dispatch(clearWishlist())}
+            >
+              Clear all
+            </button>
+          </div>
+        )}
+      </div>
+
+      {items.length === 0 ? (
+        <div className='empty-state'>
+          <p className='empty-state__title'>Nothing saved yet</p>
+          <p className='empty-state__copy'>
+            Tap the heart on any craft to keep it here while you decide.
+          </p>
+          <Link to='/' className='btn'>
+            Browse the crafts
+          </Link>
+        </div>
+      ) : (
+        <div className='product-grid'>
+          {items.map((product) => (
+            <Product key={product._id} product={product} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WishlistScreen;

--- a/frontend/src/screens/admin/OrderListScreen.jsx
+++ b/frontend/src/screens/admin/OrderListScreen.jsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { FaTimes } from 'react-icons/fa';
 import Message from '../../components/Message';
@@ -6,13 +7,69 @@ import Meta from '../../components/Meta';
 import { useGetOrdersQuery } from '../../slices/ordersApiSlice';
 import { formatINR, formatDate } from '../../utils/formatters';
 
+const STATUS_FILTERS = [
+  { value: 'all', label: 'All' },
+  { value: 'unpaid', label: 'Awaiting payment' },
+  { value: 'undelivered', label: 'To ship' },
+  { value: 'delivered', label: 'Delivered' },
+];
+
 const OrderListScreen = () => {
   const { data: orders, isLoading, error } = useGetOrdersQuery();
+  const [status, setStatus] = useState('all');
+  const [query, setQuery] = useState('');
+
+  const visible = useMemo(() => {
+    let list = orders || [];
+    if (status === 'unpaid') list = list.filter((o) => !o.isPaid);
+    if (status === 'undelivered') list = list.filter((o) => !o.isDelivered);
+    if (status === 'delivered') list = list.filter((o) => o.isDelivered);
+
+    const q = query.trim().toLowerCase();
+    if (q) {
+      list = list.filter(
+        (o) =>
+          o._id.toLowerCase().includes(q) ||
+          (o.user?.name || '').toLowerCase().includes(q)
+      );
+    }
+    return list;
+  }, [orders, status, query]);
 
   return (
     <div className='container page'>
       <Meta title='Orders — Nargis admin' />
-      <h1>Orders</h1>
+      <div className='page-title-row'>
+        <h1>Orders</h1>
+        {orders && (
+          <span className='result-count'>
+            {visible.length} of {orders.length}
+          </span>
+        )}
+      </div>
+
+      <div className='admin-toolbar'>
+        <div className='segmented'>
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f.value}
+              type='button'
+              className={status === f.value ? 'segmented__btn is-active' : 'segmented__btn'}
+              onClick={() => setStatus(f.value)}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <input
+          type='search'
+          className='field__input admin-toolbar__search'
+          placeholder='Search by order ID or customer…'
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label='Search orders'
+        />
+      </div>
 
       {isLoading ? (
         <Loader />
@@ -20,8 +77,12 @@ const OrderListScreen = () => {
         <Message variant='danger'>
           {error?.data?.message || error.error}
         </Message>
-      ) : orders.length === 0 ? (
-        <Message>No orders yet.</Message>
+      ) : visible.length === 0 ? (
+        <Message>
+          {orders.length === 0
+            ? 'No orders yet.'
+            : 'No orders match this filter.'}
+        </Message>
       ) : (
         <div className='table-wrap'>
           <table className='table'>
@@ -38,7 +99,7 @@ const OrderListScreen = () => {
               </tr>
             </thead>
             <tbody>
-              {orders.map((order) => (
+              {visible.map((order) => (
                 <tr key={order._id}>
                   <td className='cell-mono'>{order._id.slice(-8)}</td>
                   <td>{order.user && order.user.name}</td>

--- a/frontend/src/slices/wishlistSlice.js
+++ b/frontend/src/slices/wishlistSlice.js
@@ -1,0 +1,63 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const STORAGE_KEY = 'wishlist';
+
+const readStored = () => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : { items: [] };
+  } catch {
+    return { items: [] };
+  }
+};
+
+const persist = (state) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  return state;
+};
+
+// Saved items live in localStorage rather than the database — a shopper can
+// build a wishlist before deciding to create an account.
+const wishlistSlice = createSlice({
+  name: 'wishlist',
+  initialState: readStored(),
+  reducers: {
+    toggleWishlist: (state, action) => {
+      const product = action.payload;
+      const exists = state.items.find((x) => x._id === product._id);
+      state.items = exists
+        ? state.items.filter((x) => x._id !== product._id)
+        : [
+            ...state.items,
+            {
+              _id: product._id,
+              name: product.name,
+              image: product.image,
+              price: product.price,
+              brand: product.brand,
+              category: product.category,
+              rating: product.rating,
+              numReviews: product.numReviews,
+              countInStock: product.countInStock,
+            },
+          ];
+      return persist(state);
+    },
+    removeFromWishlist: (state, action) => {
+      state.items = state.items.filter((x) => x._id !== action.payload);
+      return persist(state);
+    },
+    clearWishlist: (state) => {
+      state.items = [];
+      return persist(state);
+    },
+  },
+});
+
+export const { toggleWishlist, removeFromWishlist, clearWishlist } =
+  wishlistSlice.actions;
+
+export const selectIsWishlisted = (productId) => (state) =>
+  state.wishlist.items.some((x) => x._id === productId);
+
+export default wishlistSlice.reducer;

--- a/frontend/src/slices/wishlistSlice.test.js
+++ b/frontend/src/slices/wishlistSlice.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import reducer, {
+  toggleWishlist,
+  removeFromWishlist,
+  clearWishlist,
+} from './wishlistSlice';
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', {
+    setItem: vi.fn(),
+    getItem: vi.fn(() => null),
+  });
+});
+
+const product = {
+  _id: 'p1',
+  name: 'Kani Pashmina Shawl',
+  image: '/images/kani-shawl.jpg',
+  price: 14950,
+  brand: 'Kanihama Loomworks',
+  category: 'Shawls & Stoles',
+  rating: 4.7,
+  numReviews: 3,
+  countInStock: 4,
+};
+
+describe('wishlistSlice', () => {
+  it('adds a product that is not saved yet', () => {
+    const state = reducer({ items: [] }, toggleWishlist(product));
+    expect(state.items).toHaveLength(1);
+    expect(state.items[0]._id).toBe('p1');
+  });
+
+  it('toggles the same product back off', () => {
+    const added = reducer({ items: [] }, toggleWishlist(product));
+    const removed = reducer(added, toggleWishlist(product));
+    expect(removed.items).toHaveLength(0);
+  });
+
+  it('stores only the fields a card needs to render', () => {
+    const state = reducer(
+      { items: [] },
+      toggleWishlist({ ...product, reviews: [1, 2, 3], description: 'long…' })
+    );
+    expect(state.items[0]).not.toHaveProperty('reviews');
+    expect(state.items[0]).not.toHaveProperty('description');
+    expect(state.items[0].price).toBe(14950);
+  });
+
+  it('removes by id', () => {
+    const added = reducer({ items: [] }, toggleWishlist(product));
+    const state = reducer(added, removeFromWishlist('p1'));
+    expect(state.items).toHaveLength(0);
+  });
+
+  it('clears everything', () => {
+    let state = reducer({ items: [] }, toggleWishlist(product));
+    state = reducer(state, toggleWishlist({ ...product, _id: 'p2' }));
+    expect(reducer(state, clearWishlist()).items).toHaveLength(0);
+  });
+
+  it('persists to localStorage on every change', () => {
+    reducer({ items: [] }, toggleWishlist(product));
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'wishlist',
+      expect.stringContaining('p1')
+    );
+  });
+});

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,17 +1,19 @@
-import {configureStore} from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import { apiSlice } from './slices/apiSlice';
-import cartSliceReducer from './slices/cartSlice'
+import cartSliceReducer from './slices/cartSlice';
 import authSliceReducer from './slices/authSlice';
-const store = configureStore({
-    reducer:{
-        [apiSlice.reducerPath]: apiSlice.reducer,
-        cart: cartSliceReducer,
-        auth: authSliceReducer,
+import wishlistSliceReducer from './slices/wishlistSlice';
 
-    },
-    middleware: (getDefaultMiddleware)=> getDefaultMiddleware().concat(apiSlice.middleware),
-    devTools:true,
+const store = configureStore({
+  reducer: {
+    [apiSlice.reducerPath]: apiSlice.reducer,
+    cart: cartSliceReducer,
+    auth: authSliceReducer,
+    wishlist: wishlistSliceReducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(apiSlice.middleware),
+  devTools: true,
 });
 
-
-export default store
+export default store;

--- a/frontend/src/utils/recentlyViewed.js
+++ b/frontend/src/utils/recentlyViewed.js
@@ -1,0 +1,38 @@
+const STORAGE_KEY = 'recentlyViewed';
+const MAX_ITEMS = 8;
+
+const read = () => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const getRecentlyViewed = (excludeId) =>
+  read().filter((item) => item._id !== excludeId);
+
+// Most recent first, de-duplicated, capped so the rail stays short.
+export const recordProductView = (product) => {
+  if (!product?._id) return;
+
+  const entry = {
+    _id: product._id,
+    name: product.name,
+    image: product.image,
+    price: product.price,
+    rating: product.rating,
+  };
+
+  const next = [entry, ...read().filter((x) => x._id !== product._id)].slice(
+    0,
+    MAX_ITEMS
+  );
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // storage full or unavailable — the rail is a nicety, not worth failing over
+  }
+};


### PR DESCRIPTION
- Add responsive scroll-margin-top to #crafts / #reviews / #main-content so "Shop the crafts" no longer parks the category chips behind the sticky header (the mobile header is ~2x taller, hence the breakpoint)
- Submitting an empty search opens /search listing the whole catalogue ("Everything we make") instead of silently returning home; adds /search and /search/page/:n routes, pagination, and ScrollToTop support